### PR TITLE
ENH: reduce number of layers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,15 @@
 FROM python:3-alpine
 
-ENV REDIS_URL 'redis://redis:6379'
-ENV DJANGO_SETTINGS_MODULE 'settings'
+ENV REDIS_URL="redis://redis:6379" \
+    DJANGO_SETTINGS_MODULE="settings"
 
 ADD ./ /opt/otree
 
 RUN apk -U add --no-cache postgresql-dev gcc musl-dev curl \
                           bash postgresql \
     && pip install -r /opt/otree/requirements.txt \
-    && curl https://bin.equinox.io/c/ekMN3bCZFUn/forego-stable-linux-amd64.tgz -O \
-	&& cd /usr/local/bin \
-	&& tar -xf /forego-stable-linux-amd64.tgz \
-	&& rm /forego-stable-linux-amd64.tgz \
+    && curl https://bin.equinox.io/c/ekMN3bCZFUn/forego-stable-linux-amd64.tgz \
+    | tar -x -C /usr/local/bin \
     && mkdir -p /opt/init \
     && chmod +x /opt/otree/entrypoint.sh \
     && apk del postgresql-dev gcc musl-dev curl

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,16 +5,19 @@ ENV REDIS_URL="redis://redis:6379" \
 
 ADD ./ /opt/otree
 
-RUN apk -U add --no-cache postgresql-dev gcc musl-dev curl \
-                          bash postgresql \
-    && pip install -r /opt/otree/requirements.txt \
+RUN apk -U add --no-cache bash \
+                          curl \
+                          gcc \
+                          musl-dev \
+                          postgresql \
+                          postgresql-dev \
+    && pip install --no-cache-dir -r /opt/otree/requirements.txt \
     && curl https://bin.equinox.io/c/ekMN3bCZFUn/forego-stable-linux-amd64.tgz \
-    | tar -x -C /usr/local/bin \
+    | tar -xz -C /usr/local/bin \
     && mkdir -p /opt/init \
     && chmod +x /opt/otree/entrypoint.sh \
-    && apk del postgresql-dev gcc musl-dev curl
-
-RUN echo "oTree: /bin/bash -c 'cd /opt/otree && otree runprodserver --port=80'"> /Procfile
+    && apk del curl gcc musl-dev postgresql-dev \
+    && echo "oTree: /bin/bash -c 'cd /opt/otree && otree runprodserver --port=80'"> /Procfile
 
 WORKDIR /opt/otree
 VOLUME /opt/init


### PR DESCRIPTION
This PR combines both `ENV` instructions, alphabetizes the `apk` packages, streamlines the installation of forego, and combines two `RUN` instructions.

The changes should make the Dockerfile more readable and reduces layer caches.